### PR TITLE
Fetching COVID2 related interactions: complex and IntAct data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ OTSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.04/i
 OTBASELINEBUCKET=https://github.com/opentargets/expression_analysis/blob/master/exp_summary_NormCounts_genes.txt
 OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.04/output/20.04_evidence_data.json.gz
 
+# COVID complex file:
+COVIDCOMPLEXURL=http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/current/complextab/sars-cov-2.tsv
+
+# IntAct COVID related interaction query:
+INTACTCOVIDURL="https://www.ebi.ac.uk/intact/export?format=mitab_27&query=annot%3A%22dataset%3ACoronavirus%22&negative=false&spoke=false&ontology=false&sort=intact-miscore&asc=false" 
+
 #################################
 # Paths (DIRECTORIES)
 #################################
@@ -33,7 +39,6 @@ DATADIR= $(ROOTDIR)/temp
 CURL ?= $(shell which curl)
 GUNZIP ?= $(shell which gunzip)
 
-
 #################################
 # Relevant files
 #################################
@@ -43,6 +48,8 @@ OTTRACTABILITY=$(TEMPDIR)/ot_tractability.tsv
 OTSAFETY=$(TEMPDIR)/ot_safety.json
 OTBASELINE=$(TEMPDIR)/ot_baseline.txt
 OTEVIDENCE=$(TEMPDIR)/ot_evidence.json
+COVIDCOMPLEX=$(TEMPDIR)/complex_sars-cov-2.tsv  
+INTACTCOVID=$(TEMPDIR)/IntAct_SARS-COV-2_interactions.tsv
 
 #### Phony targets
 .PHONY: all downloads create-temp
@@ -54,7 +61,7 @@ all: create-temp downloads
 # Downloads
 #############
 
-downloads: create-temp $(UNIPROTCOVIDFLATFILE) $(OTTRACTABILITY) $(OTSAFETY) $(OTBASELINE) $(OTEVIDENCE)
+downloads: create-temp $(UNIPROTCOVIDFLATFILE) $(OTTRACTABILITY) $(OTSAFETY) $(OTBASELINE) $(OTEVIDENCE) $(COVIDCOMPLEX) $(INTACTCOVID)
 
 # CREATES TEMPORARY DIRECTORY
 create-temp:
@@ -74,3 +81,11 @@ $(OTBASELINE):
 
 $(OTEVIDENCE):
 	$(CURL) $(OTEVIDENCEBUCKET) | $(GUNZIP) -c > $@
+
+$(COVIDCOMPLEX):
+	$(CURL)  $(COVIDCOMPLEXURL) > $@
+
+$(INTACTCOVID):
+	$(CURL) $(INTACTCOVIDURL) > $@
+
+


### PR DESCRIPTION
Building of two new sources are now implemented:

1. Complex data sourced from [here](http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/current/complextab/)
2. All corona virus related interaction from IntAct [queried](https://www.ebi.ac.uk/intact/query/annot:%22dataset:Coronavirus%22) and saved as tab separated file.

Fetching these files worked for me. We might want to include new scripts in the repo to parse these files. (Generating the specified network format.)