### PR TITLE
uniprot parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,49 +53,70 @@ PIPENV ?= $(shell which pipenv)
 #################################
 
 ROOTDIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-TEMPDIR= $(ROOTDIR)/temp
 SRCDIR= $(ROOTDIR)/src
-DATADIR= $(ROOTDIR)/temp
+DATADIR= $(ROOTDIR)/data
+TEMPDIR= $(ROOTDIR)/temp
+RAWDIR ?= $(TEMPDIR)/raw_files
+PARSEDDIR ?= $(TEMPDIR)/parsed_tables
+PREFORMATEDDIR ?= $(TEMPDIR)/preformated_tables
 
 #################################
-# Relevant files
+# RAW FILES
 #################################
 
 ## Uniprot
-UNIPROTCOVIDFLATFILE=$(TEMPDIR)/uniprot_covid19.json
-UNIPROTCOVIDPARSED=$(TEMPDIR)/uniprot_covid19_parsed.tsv
-UNIPROTIDMAPPING=$(TEMPDIR)/uniprot_human_idmapping.dat
+UNIPROTCOVIDFLATFILE=$(RAWDIR)/uniprot_covid19.json
+UNIPROTIDMAPPING=$(RAWDIR)/uniprot_human_idmapping.dat
 ## Ensembl
-ENSEMBL=$(TEMPDIR)/ensembl.json
-ENSEMBLPARSED=$(TEMPDIR)/ensembl_parsed.json.gz
+ENSEMBL=$(RAWDIR)/ensembl.json
 ## proteins in human infecting coronavirus
-WIKIDATAPROTEINS=$(TEMPDIR)/wikidata_proteins.tsv
+WIKIDATAPROTEINS=$(RAWDIR)/wikidata_proteins.tsv
 ## OT
-OTTRACTABILITY=$(TEMPDIR)/ot_tractability.tsv
-OTSAFETY=$(TEMPDIR)/ot_safety.json
-OTBASELINE=$(TEMPDIR)/ot_baseline.txt
-OTEVIDENCE=$(TEMPDIR)/ot_evidence.json
+OTTRACTABILITY=$(RAWDIR)/ot_tractability.tsv
+OTSAFETY=$(RAWDIR)/ot_safety.json
+OTBASELINE=$(RAWDIR)/ot_baseline.txt
+OTEVIDENCE=$(RAWDIR)/ot_evidence.json
 ## Drugs
-OTDRUGEVIDENCE=$(TEMPDIR)/ot_drug_evidence.tsv
-WIKIDATATRIALS=$(TEMPDIR)/wiki_trials.tsv
-CHEMBLMOLECULE=$(TEMPDIR)/chembl_molecules.json
-CHEMBLDRUGINDICATION=$(TEMPDIR)/chembl_indication.json
-CHEMBLTARGETS=$(TEMPDIR)/chembl_targets.json
-CHEMBLTARGETCOMPONENTS=$(TEMPDIR)/chembl_target_components.json
-CHEMBLMOA=$(TEMPDIR)/chembl_mechanisms.json
-
+WIKIDATATRIALS=$(RAWDIR)/wiki_trials.tsv
+CHEMBLMOLECULE=$(RAWDIR)/chembl_molecules.json
+CHEMBLDRUGINDICATION=$(RAWDIR)/chembl_indication.json
+CHEMBLTARGETS=$(RAWDIR)/chembl_targets.json
+CHEMBLTARGETCOMPONENTS=$(RAWDIR)/chembl_target_components.json
+CHEMBLMOA=$(RAWDIR)/chembl_mechanisms.json
 ## Interactions
-COVIDCOMPLEX=$(TEMPDIR)/complex_sars-cov-2.tsv
-COVIDCOMPLEXPARSED=$(TEMPDIR)/complex_sars-cov-2_parsed.tsv
+COVIDCOMPLEX=$(RAWDIR)/complex_sars-cov-2.tsv
+INTACTCOVID=$(RAWDIR)/IntAct_SARS-COV-2_interactions.tsv
 
-INTACTCOVID=$(TEMPDIR)/IntAct_SARS-COV-2_interactions.tsv
-INTACTCOVIDPARSED=$(TEMPDIR)/IntAct_SARS-COV-2_interactions_parsed.tsv
+######################################################
+# PARSED FILES - Files with some intermediate parsing
+######################################################
+
+## Uniprot
+UNIPROTCOVIDPARSED=$(PARSEDDIR)/uniprot_covid19_parsed.tsv
+## OT
+OTDRUGEVIDENCE=$(PARSEDDIR)/ot_drug_evidence.tsv
+## Ensembl
+ENSEMBLPARSED=$(PARSEDDIR)/ensembl_parsed.json.gz
+## Interactions
+COVIDCOMPLEXPARSED=$(PARSEDDIR)/complex_sars-cov-2_parsed.tsv
+INTACTCOVIDPARSED=$(PARSEDDIR)/IntAct_SARS-COV-2_interactions_parsed.tsv
+
+###############################################################
+# PREFORMATED FILES - Files already formatted to be integrated
+###############################################################
+
+#TODO
+
+#############################################################################
 
 #### Phony targets
-.PHONY: all setup-environment downloads create-temp parsers
+.PHONY: all setup-environment clean-all downloads create-temp parsers
 
 # ALL
 all: setup-environment create-temp downloads parsers
+
+clean-all:
+	rm -rf $(TEMPDIR)
 
 ## Setup environment
 setup-environment:
@@ -110,16 +131,19 @@ parsers: $(OTDRUGEVIDENCE) $(UNIPROTCOVIDPARSED) $(COVIDCOMPLEXPARSED) $(INTACTC
 # CREATES TEMPORARY DIRECTORY
 create-temp:
 	mkdir -p $(TEMPDIR)
+	mkdir -p $(RAWDIR)
+	mkdir -p $(PARSEDDIR)
+	mkdir -p $(PREFORMATEDDIR)
 
 ##
 ## Fetching data:
 ##
 
 $(UNIPROTIDMAPPING):
-	$(CURL) $(UNIPROTCOVIDQUERY) > $@
+	$(CURL) $(UNIPROTIDMAPPINGURL) | $(GUNZIP) -c > $@
 
 $(UNIPROTCOVIDFLATFILE):
-	$(CURL) $(UNIPROTCOVIDFTP) > $@
+	$(CURL) $(UNIPROTCOVIDQUERY) > $@
 
 $(ENSEMBL):
 	$(CURL) $(ENSEMBLURL) | $(JQ) -r '.genes[] | @json' > $(ENSEMBL)
@@ -169,7 +193,7 @@ $(INTACTCOVID):
 ##
 
 $(UNIPROTCOVIDPARSED): $(UNIPROTCOVIDFLATFILE)
-	$(PIPENV) run python $(SRCDIR)/parsers/uniprot_parser.py -i $(UNIPROTCOVIDFLATFILE) > $@
+	$(PIPENV) run python $(SRCDIR)/parsers/uniprot_parser.py -i $(UNIPROTCOVIDFLATFILE) -o $@
 
 $(OTDRUGEVIDENCE):
 	$(JQ) -r 'select(.sourceID == "chembl") | [.target.id, .disease.id, .drug.id, .evidence.drug2clinic.clinical_trial_phase.numeric_index, .evidence.target2drug.action_type, .drug.molecule_name] | @tsv' $(OTEVIDENCE) | $(SED) -e 's/http:\/\/identifiers.org\/chembl.compound\///g' > $@
@@ -182,3 +206,4 @@ $(ENSEMBLPARSED):
 
 $(INTACTCOVIDPARSED):
 	$(PIPENV) run python $(SRCDIR)/parsers/intact_parser.py -i $(INTACTCOVID) -o $(INTACTCOVIDPARSED)
+

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #################################
 
 # Uniprot covid19 flat file
-UNIPROTCOVIDFTP=ftp://ftp.uniprot.org/pub/databases/uniprot/pre_release/covid-19.dat
+UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/download?format=json&query=%2A"
 UNIPROTIDMAPPINGURL=ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
 
 # OT files
@@ -62,7 +62,7 @@ DATADIR= $(ROOTDIR)/temp
 #################################
 
 ## Uniprot
-UNIPROTCOVIDFLATFILE=$(TEMPDIR)/uniprot_covid19.dat
+UNIPROTCOVIDFLATFILE=$(TEMPDIR)/uniprot_covid19.json
 UNIPROTCOVIDPARSED=$(TEMPDIR)/uniprot_covid19_parsed.tsv
 UNIPROTIDMAPPING=$(TEMPDIR)/uniprot_human_idmapping.dat
 ## Ensembl
@@ -116,7 +116,7 @@ create-temp:
 ##
 
 $(UNIPROTIDMAPPING):
-	$(CURL) $(UNIPROTIDMAPPINGURL) | $(GUNZIP) -c > $@
+	$(CURL) $(UNIPROTCOVIDQUERY) > $@
 
 $(UNIPROTCOVIDFLATFILE):
 	$(CURL) $(UNIPROTCOVIDFTP) > $@

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-biopython = {editable = true,git = "https://github.com/biopython/biopython.git"}
 pandas = "*"
+requests = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb75629dd703180be69d34b61162a8939e2c34c1a6b03a60eaa02583c30e1ec9"
+            "sha256": "5f1f7a51d972febb5993d257bfd9214ef725f2ad5f17c33b59b75af57fb27417"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,10 +16,26 @@
         ]
     },
     "default": {
-        "biopython": {
-            "editable": true,
-            "git": "https://github.com/biopython/biopython.git",
-            "ref": "2f02e34ba76306e9c27eec9e051809bec2cece9b"
+        "certifi": {
+            "hashes": [
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+            ],
+            "version": "==2020.4.5.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
         },
         "numpy": {
             "hashes": [
@@ -78,10 +94,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
-            "version": "==2019.3"
+            "version": "==2020.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "index": "pypi",
+            "version": "==2.23.0"
         },
         "six": {
             "hashes": [
@@ -89,6 +113,13 @@
                 "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
             "version": "==1.14.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "version": "==1.25.9"
         }
     },
     "develop": {}

--- a/src/parsers/uniprot_parser.py
+++ b/src/parsers/uniprot_parser.py
@@ -1,45 +1,78 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import argparse
-import Bio.SwissProt as sp
+import json 
+import requests
+import pandas as pd 
 
-###########
-# MAIN
-###########
+
+def map_primary_uniprot_accession_to_ensembl(row):
+    organism = row['organism_scientific_name'].replace(' ','_').lower()
+    accession = row['primaryAccession']
+    URL = 'http://rest.ensembl.org/xrefs/symbol/{}/{}?content-type=application/json&object_type=gene'.format(
+        organism,accession)
+
+    response = requests.get(URL).json()
+
+    if 'error' in response:
+        print('[Warning] Could not find Ensembl gene ID to {}'.format(accession))
+        return None
+    
+    try:
+        return response[0]['id'] if len(response) > 0 else None
+    except:
+        return None
+
+
+def main():
+    """
+    Reading Uniprot JSON files.
+    """
+
+    # Reading arguments
+    parser = argparse.ArgumentParser(description='Parse uniprot .json file')
+    parser.add_argument('-i','--inputfile',required=True, dest="UNIPROT_IN", type=str, help='input uniprot dat file to parse')
+    parser.add_argument('-o','--outputfile',required=True, dest="UNIPROT_OUT", type=str, help='Parsed tsv file name.')
+
+    args = parser.parse_args()
+    uniprot_file = args.UNIPROT_IN
+    outputFile = args.UNIPROT_OUT
+
+    # Open json file:
+    with open(uniprot_file) as f:
+        uniprot_data = json.load(f)
+
+    # Parsing json data:
+    parsed_entries= []
+    for entry in uniprot_data['results']:
+
+        # Pick simle pieces:
+        parsed_entry = {
+            'primaryAccession': entry['primaryAccession'],
+            'uniprot_name': entry['uniProtkbId'],
+            'organism_name': entry['organism']['commonName'],
+            'organism_id': entry['organism']['taxonId'],
+            'organism_scientific_name': entry['organism']['scientificName']
+        }
+        
+        # Seconday accessions might not provided:
+        parsed_entry['secondaryAccessions'] = ','.join(entry['secondaryAccessions']) if 'secondaryAccessions' in entry else None
+        
+        # Adding parsed data:
+        parsed_entries.append(parsed_entry)
+        
+    # Format data into dataframe:
+    parsed_entries_df = pd.DataFrame(parsed_entries)
+
+    # Mapping primary uniprot accessions to Ensembl gene id:
+    print('[Info] Mapping primary Uniprot identifiers to Ensembl gene id...')
+    parsed_entries_df['gene_id'] = parsed_entries_df.apply(map_primary_uniprot_accession_to_ensembl, axis=1)
+
+    # Save file:
+    parsed_entries_df.to_csv(outputFile, sep='\t', index=False)
+
 
 if __name__ == '__main__':
-  # Reading arguments
-  parser = argparse \
-    .ArgumentParser(
-      description='Parse uniprot .dat file')
-  parser.add_argument('-i',
-                      '--inputfile',
-                      required=True,
-                      action="store",
-                      metavar="PATH",
-                      dest="UNIPROT_IN",
-                      help='input uniprot dat file to parse')
-  # parser.add_argument('-o',
-  #                     '--outputfile',
-  #                     required=True,
-  #                     action="store",
-  #                     metavar="PATH",
-  #                     dest="UNIPROT_OUT",
-  #                     help='path for parsed uniprot file')
+    main()
 
-  results = parser.parse_args()
-  UNIPROTFILE = results.UNIPROT_IN
-  # OUTPUTFILE = results.UNIPROT_OUT
 
-  ## TODO: parse appropiately
-  ## For future reference on fields
-  ## https://biopython.org/DIST/docs/api/Bio.SwissProt-pysrc.html
-  with open(UNIPROTFILE) as handle:
-    records = sp.parse(handle)
-    for record in records:
-      print(record.entry_name)
-      print(",".join(record.accessions))
-      print(repr(record.organism))
-      print("\n")


### PR DESCRIPTION
**Changes:**

1. Instead of the `.dat` file we are fetching the covid related Uniprot entries are fetched as JSON.
2. The parser extracts fields and saves as `.tsv`.
3. Makefile updated.
4. `Biopython` removed from `Pipfile`

**Parsed file looks like this:**

| Header | Value |
|--------|-------|
| primaryAccession | O15393 | 
| uniprot_name  | TMPS2_HUMAN | 
| organism_name  | Human | 
| organism_id  | 9606 | 
| organism_scientific_name  | Homo_sapiens | 
| secondaryAccessions  | A8K6Z8,B2R8E5,B7Z459,D3DSJ2,F8WES1,Q6GTK7,Q9BXX1 | 
| gene_id  | ENSG00000184012 | 