### PR TITLE
Integrator script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,15 +105,15 @@ INTACTCOVIDPARSED=$(PARSEDDIR)/IntAct_SARS-COV-2_interactions_parsed.tsv
 # PREFORMATED FILES - Files already formatted to be integrated
 ###############################################################
 
-#TODO
+INTEGRATED=$(TEMPDIR)/integrated_data.tsv
 
 #############################################################################
 
 #### Phony targets
-.PHONY: all setup-environment clean-all downloads create-temp parsers
+.PHONY: all setup-environment clean-all downloads create-temp parsers integrate
 
 # ALL
-all: setup-environment create-temp downloads parsers
+all: setup-environment create-temp downloads parsers integrate
 
 clean-all:
 	rm -rf $(TEMPDIR)
@@ -134,6 +134,9 @@ create-temp:
 	mkdir -p $(RAWDIR)
 	mkdir -p $(PARSEDDIR)
 	mkdir -p $(PREFORMATEDDIR)
+
+## Run integrator:
+integrate: $(INTEGRATED)
 
 ##
 ## Fetching data:
@@ -207,3 +210,9 @@ $(ENSEMBLPARSED):
 $(INTACTCOVIDPARSED):
 	$(PIPENV) run python $(SRCDIR)/parsers/intact_parser.py -i $(INTACTCOVID) -o $(INTACTCOVIDPARSED)
 
+##
+## Integrate:
+##
+
+$(INTEGRATED):
+		$(PIPENV) run python $(SRCDIR)/covid_data_integration.py -i $(PARSEDDIR) -o $(INTEGRATED)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ TEMPDIR= $(ROOTDIR)/temp
 RAWDIR ?= $(TEMPDIR)/raw_files
 PARSEDDIR ?= $(TEMPDIR)/parsed_tables
 PREFORMATEDDIR ?= $(TEMPDIR)/preformated_tables
+RESULTDIR ?= $(TEMPDIR)/results
 
 #################################
 # RAW FILES
@@ -92,7 +93,7 @@ INTACTCOVID=$(RAWDIR)/IntAct_SARS-COV-2_interactions.tsv
 ######################################################
 
 ## Uniprot
-UNIPROTCOVIDPARSED=$(PARSEDDIR)/uniprot_covid19_parsed.tsv
+UNIPROTCOVIDPARSED=$(PREFORMATEDDIR)/uniprot_covid19_parsed.tsv
 ## OT
 OTDRUGEVIDENCE=$(PARSEDDIR)/ot_drug_evidence.tsv
 ## Ensembl
@@ -105,7 +106,7 @@ INTACTCOVIDPARSED=$(PARSEDDIR)/IntAct_SARS-COV-2_interactions_parsed.tsv
 # PREFORMATED FILES - Files already formatted to be integrated
 ###############################################################
 
-INTEGRATED=$(TEMPDIR)/integrated_data.tsv
+INTEGRATED=$(RESULTDIR)/integrated_data.tsv
 
 #############################################################################
 
@@ -134,6 +135,7 @@ create-temp:
 	mkdir -p $(RAWDIR)
 	mkdir -p $(PARSEDDIR)
 	mkdir -p $(PREFORMATEDDIR)
+	mkdir -p $(RESULTDIR)
 
 ## Run integrator:
 integrate: $(INTEGRATED)
@@ -215,4 +217,10 @@ $(INTACTCOVIDPARSED):
 ##
 
 $(INTEGRATED):
-		$(PIPENV) run python $(SRCDIR)/covid_data_integration.py -i $(PREFORMATEDDIR) -o $(INTEGRATED)
+		$(PIPENV) run python $(SRCDIR)/integrators/covid_data_integration.py \
+			-r $(ENSEMBLPARSED) \
+			-o $(INTEGRATED) \
+			-i $(PREFORMATEDDIR) \
+			-c $(SRCDIR)/integrators/integration_config.json
+
+

--- a/Makefile
+++ b/Makefile
@@ -215,4 +215,4 @@ $(INTACTCOVIDPARSED):
 ##
 
 $(INTEGRATED):
-		$(PIPENV) run python $(SRCDIR)/covid_data_integration.py -i $(PARSEDDIR) -o $(INTEGRATED)
+		$(PIPENV) run python $(SRCDIR)/covid_data_integration.py -i $(PREFORMATEDDIR) -o $(INTEGRATED)

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 pandas = "*"
 requests = "*"
+openpyxl = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f1f7a51d972febb5993d257bfd9214ef725f2ad5f17c33b59b75af57fb27417"
+            "sha256": "cc4d009e65b3eec77e4138adfff9593f88fe66f19967f312e3634ca9e4dc853b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,12 +30,25 @@
             ],
             "version": "==3.0.4"
         },
+        "et-xmlfile": {
+            "hashes": [
+                "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
+            ],
+            "version": "==1.0.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
+        },
+        "jdcal": {
+            "hashes": [
+                "sha256:1abf1305fce18b4e8aa248cf8fe0c56ce2032392bc64bbd61b5dff2a19ec8bba",
+                "sha256:472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8"
+            ],
+            "version": "==1.4.1"
         },
         "numpy": {
             "hashes": [
@@ -62,6 +75,13 @@
                 "sha256:fdee7540d12519865b423af411bd60ddb513d2eb2cd921149b732854995bbf8b"
             ],
             "version": "==1.18.3"
+        },
+        "openpyxl": {
+            "hashes": [
+                "sha256:547a9fc6aafcf44abe358b89ed4438d077e9d92e4f182c87e2dc294186dc4b64"
+            ],
+            "index": "pypi",
+            "version": "==3.0.3"
         },
         "pandas": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -25,29 +25,13 @@ make all
 
 `make all` downloads all data, builds Python environment, run parsers and the integrator script(s).
 
-#### Fetch data only:
+#### Other actions:
 
-```bash
-make downloads
-```
-
-#### Run parsers only:
-
-```bash
-make parsers
-```
-
-#### Run integrator:
-
-```bash
-make integrator
-```
-
-#### Remove temporary files:
-
-```bash
-make clean
-```
+* `make setup-environment` - building Python environment
+* `make downloads` - download files only
+* `make parsers` - run parsers only
+* `make integrator` - run integrator(s) only
+* `make clean-all` - removing temporary files.
 
 ## Directory structure
 
@@ -69,9 +53,10 @@ make clean
 
 For the integration part the concept is that we want to keep out logic altogether from the integrator scripts. All data processing steps should happen earlier in the parsing and pre-processing steps. Integrator scripts take tables with columns that are ready to be added to the final tables. So there are a few requirements:
 
-1. Tables are read from `/temp/preformated_tables` directory only.
+1. Tables are read from `/temp/preformated_tables` directory only
+2. The tables must be in an uncompressed tsv format
 2. Tables must have a column called `id` containing unique identifiers (eg. Ensembl gene id or Uniprot primary accession)
-3. Tables to be integrated must be added to the integration config files describing how the integration should happen.
+3. Tables to be integrated must be added to the integration config files describing how the integration should happen
 
 #### Integration configuration:
 
@@ -98,7 +83,7 @@ Where:
 * `columns_to_map` - column mapping to populate existing fields for the new targets.
 
 
-This recipe shows how to integrate a dataset where we are not expecting new targets, and two new columns are added to the dataset:
+This recipe shows how to integrate a dataset where we are not expecting new targets, and two new columns are added to the final table:
 
 ```json
 "ot_drugs_processed.tsv": {

--- a/README.md
+++ b/README.md
@@ -6,5 +6,104 @@ Centralise publicly available datasets in order to build a Virus – Host Target
 A full description of the project vision is [here](https://drive.google.com/open?id=1NzbSrh_Cqs9yCIyl-J7HjCHfNFtkVNdQ)
 Some of the questions the project is trying to answer [here](https://docs.google.com/document/d/1Tcc0lhu5YqT3-fY5N4EzPjYtd-dcKhM5y-Lu1TqGD30/edit#heading=h.clav1w5t1yv0)
 
-## Contributors
-This project is open to contributors.
+## Data flow
+
+1. Potential data sources are fetched based on URLs provided in the `Makefile` if such URL is not available, the data tables can be directly added to the `/data` folder.
+2. Relevant pieces of information is extracted from the raw source data as part of a parsing step.
+3. Data might be further processed if necessary eg. mapping cross-references, integration with other sources etc.
+4. Pre-processed tables are then picked up by the integrator script(s) and compiled into presentable tables.
+
+## Usage
+
+#### Run project from scratch:
+
+```bash
+git clone https://github.com/opentargets/ot_covid19
+cd ot_covid19
+make all
+```
+
+`make all` downloads all data, builds Python environment, run parsers and the integrator script(s).
+
+#### Fetch data only:
+
+```bash
+make downloads
+```
+
+#### Run parsers only:
+
+```bash
+make parsers
+```
+
+#### Run integrator:
+
+```bash
+make integrator
+```
+
+#### Remove temporary files:
+
+```bash
+make clean
+```
+
+## Directory structure
+
+**Data folders**:
+
+* `/data` - containing version controlled data files that cannot be directly accessed from the web
+* `/temp` - created by `make` will be populated when run locally. Data under this folder is not versioned
+* `/temp/raw_files` - raw data files fetched from the web
+* `/temp/parsed_tables` - parsed tables
+* `/temp/preformated_tables` - pre-processed data ready to be integrated
+
+**Script folders**:
+
+* `/src/parsers` - contains parser scripts
+* `/src/query` - contains SQL queries
+* `/src/integrators` - contains integrator scripts
+
+## Data integration
+
+For the integration part the concept is that we want to keep out logic altogether from the integrator scripts. All data processing steps should happen earlier in the parsing and pre-processing steps. Integrator scripts take tables with columns that are ready to be added to the final tables. So there are a few requirements:
+
+1. Tables are read from `/temp/preformated_tables` directory only.
+2. Tables must have a column called `id` containing unique identifiers (eg. Ensembl gene id or Uniprot primary accession)
+3. Tables to be integrated must be added to the integration config files describing how the integration should happen.
+
+#### Integration configuration:
+
+This recipe shows how to integrate a dataset were we are expecting new targets (eg viral proteins) that are not included in the complete human gene set:
+
+```json
+"uniprot_covid19_parsed.tsv": {
+    "columns": [], 
+    "flag": true, 
+    "flag_label": "COVID-19 UniprotKB", 
+    "how": "outer", 
+    "columns_to_map": {
+        "taxon_id": "taxon_id",
+        "uniprot_ids": "uniprot_accessions"
+    }
+}
+```
+Where:
+
+* `columns` contains the list of columns to be added. It can be empty if only flag is used.
+* `flag` - boolean, indicating if the table is used as a flag eg. marking genes that are in the COVID-19 uniprot dataset
+* `flag_label` - title of the flag column
+* `how` - describing how the join should happen. By default it is left. Use outer if you expect new targets in the integrated dataset
+* `columns_to_map` - column mapping to populate existing fields for the new targets.
+
+
+This recipe shows how to integrate a dataset where we are not expecting new targets, and two new columns are added to the dataset:
+
+```json
+"ot_drugs_processed.tsv": {
+    "columns": ["drug_names", "max_phase"], 
+    "flag": false
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Centralise publicly available datasets in order to build a Virus – Host Target
 A full description of the project vision is [here](https://drive.google.com/open?id=1NzbSrh_Cqs9yCIyl-J7HjCHfNFtkVNdQ)
 Some of the questions the project is trying to answer [here](https://docs.google.com/document/d/1Tcc0lhu5YqT3-fY5N4EzPjYtd-dcKhM5y-Lu1TqGD30/edit#heading=h.clav1w5t1yv0)
 
+## Contributors
+This project is open to contributors.
+
 ## Data flow
 
 1. Potential data sources are fetched based on URLs provided in the `Makefile` if such URL is not available, the data tables can be directly added to the `/data` folder.
@@ -15,7 +18,7 @@ Some of the questions the project is trying to answer [here](https://docs.google
 
 ## Usage
 
-#### Run project from scratch:
+#### Run project from scratch
 
 ```bash
 git clone https://github.com/opentargets/ot_covid19
@@ -58,7 +61,7 @@ For the integration part the concept is that we want to keep out logic altogethe
 2. Tables must have a column called `id` containing unique identifiers (eg. Ensembl gene id or Uniprot primary accession)
 3. Tables to be integrated must be added to the integration config files describing how the integration should happen
 
-#### Integration configuration:
+#### Integration configuration
 
 This recipe shows how to integrate a dataset were we are expecting new targets (eg viral proteins) that are not included in the complete human gene set:
 

--- a/src/covid_data_integration.py
+++ b/src/covid_data_integration.py
@@ -1,0 +1,47 @@
+import pandas as pd 
+import argparse
+import gzip
+import json
+
+# 
+
+"""
+This script integrates all COVID-19 related datasets into a single table
+"""
+
+class DataIntegrator(object):
+
+    def __init__(self, ensemblFile):
+
+        # Openind and parsing ensembl file (compressed json):
+        with 
+
+
+
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description='This script integrates COVID-19 related datasets into a single table.')
+
+    # parser.add_argument('-i', '--input', help='Folder with the input file.', required=True, type=str)
+    parser.add_argument('-e', '--ensemblFile', help='The Ensembl input file.', required=True, type=str)
+    # parser.add_argument('-o', '--output', help='Output file name.', required=True, type=str)
+
+    args = parser.parse_args()
+
+    # Get parameters:
+    # inputFolder = args.input
+    # output = args.output
+    ensemblFile = args.ensemblFile
+
+    # 1. Generate first table.
+    covid_core_data = integrator(ensemblFile)
+
+    # 2. Integrate 
+
+
+
+if __name__ == '__main__':
+    main()

--- a/src/covid_data_integration.py
+++ b/src/covid_data_integration.py
@@ -68,12 +68,18 @@ def main():
         'uniprot_covid19_parsed.tsv': {
             'columns': [], # columns to add.
             'flag': True, # Generate just a flag (indicating if a given gene/protein) is in the integrated dataset
-            'label': 'COVID-19 UniprotKB' # Label of the flag column.
+            'label': 'COVID-19 UniprotKB', # Label of the flag column.
+            'how': 'outer', # How to merge the tables
+            'columns_to_map': {
+                'taxon_id': 'taxon_id',
+                'uniprot_ids': 'uniprot_accessions'
+            }
         }
     }
 
+    # Integrating all parsed datasets:
     for source_file, parameters in input_to_parse.items():
-        integrator.add_data(source_file, columns=parameters['columns'], flag=parameters['flag'])
+        integrator.add_data(source_file, parameters=parameters)
 
 
 

--- a/src/covid_data_integration.py
+++ b/src/covid_data_integration.py
@@ -12,9 +12,33 @@ This script integrates all COVID-19 related datasets into a single table
 class DataIntegrator(object):
 
     def __init__(self, ensemblFile):
+        
+        ensembl_data = []
 
-        # Openind and parsing ensembl file (compressed json):
-        with 
+        # loading ensembl file (compressed json):
+        with gzip.open(ensemblFile,'rt') as f:
+            for line in f:
+                gene_row = json.loads(line)
+                ensembl_data.append(gene_row)
+        
+        print('[Info] Readind data complete. Number of genes: {}'.format(len(ensembl_data)))
+        print('[Info] Processing data...')
+        
+        # Once data is read, we fomat into a data frame:
+        ensembl_df = pd.DataFrame(ensembl_data)
+        
+        # Merging arrays:
+        ensembl_df.drop(columns=['PDB'], inplace=True)
+        ensembl_df.MIM_morbidity = ensembl_df.MIM_morbidity.apply(lambda x: ','.join([y['display_id'] for y in x]) if len(x)>0 else None)
+        ensembl_df.uniprot_ids = ensembl_df.uniprot_ids.apply(lambda x: ','.join(x) if len(x) > 0 else None)
+        
+        self.ensembl_df = ensembl_df
+
+
+    def add_data(self, data, columns=[], flag=False):
+        """
+        Adding a new set of data. 
+        """
 
 
 
@@ -39,7 +63,17 @@ def main():
     # 1. Generate first table.
     covid_core_data = integrator(ensemblFile)
 
-    # 2. Integrate 
+    # 2. Integrate the following files. For each files indicate which columns to be joined. If left empty, just a flag will be added. 
+    input_to_parse = {
+        'uniprot_covid19_parsed.tsv': {
+            'columns': [], # columns to add.
+            'flag': True, # Generate just a flag (indicating if a given gene/protein) is in the integrated dataset
+            'label': 'COVID-19 UniprotKB' # Label of the flag column.
+        }
+    }
+
+    for source_file, parameters in input_to_parse.items():
+        integrator.add_data(source_file, columns=parameters['columns'], flag=parameters['flag'])
 
 
 

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -49,38 +49,31 @@ def main():
     parser = argparse.ArgumentParser()
     parser = argparse.ArgumentParser(description='This script integrates COVID-19 related datasets into a single table.')
 
-    # parser.add_argument('-i', '--input', help='Folder with the input file.', required=True, type=str)
-    parser.add_argument('-e', '--ensemblFile', help='The Ensembl input file.', required=True, type=str)
-    # parser.add_argument('-o', '--output', help='Output file name.', required=True, type=str)
+    parser.add_argument('-r', '--reference', help='File with the reference dataset.', required=True, type=str)
+    parser.add_argument('-c', '--config', help='Configuration file describing integration recipes.', required=True, type=str)
+    parser.add_argument('-i', '--inputFolder', help='Folder from which the integrated files are read.', required=True, type=str)
+    parser.add_argument('-o', '--output', help='Output file name.', required=True, type=str)
 
     args = parser.parse_args()
 
     # Get parameters:
-    # inputFolder = args.input
-    # output = args.output
-    ensemblFile = args.ensemblFile
+    config_file = args.config
+    ensembl_file = args.reference
+    input_folder = args.inputFolder
+    output_file = args.output
+
+    ## TODO: add tests here.
 
     # 1. Generate first table.
     covid_core_data = integrator(ensemblFile)
 
-    # 2. Integrate the following files. For each files indicate which columns to be joined. If left empty, just a flag will be added. 
-    input_to_parse = {
-        'uniprot_covid19_parsed.tsv': {
-            'columns': [], # columns to add.
-            'flag': True, # Generate just a flag (indicating if a given gene/protein) is in the integrated dataset
-            'label': 'COVID-19 UniprotKB', # Label of the flag column.
-            'how': 'outer', # How to merge the tables
-            'columns_to_map': {
-                'taxon_id': 'taxon_id',
-                'uniprot_ids': 'uniprot_accessions'
-            }
-        }
-    }
+    # 2. Reading configuration:
+    with open(config_file, 'rt') as f:
+        config_data = json.load(f)
 
     # Integrating all parsed datasets:
-    for source_file, parameters in input_to_parse.items():
-        integrator.add_data(source_file, parameters=parameters)
-
+    for source_file, parameters in config_data.items():
+        integrator.add_data('{}/{}'.format(input_folder, source_file), parameters=parameters)
 
 
 if __name__ == '__main__':

--- a/src/integrators/integration_config.json
+++ b/src/integrators/integration_config.json
@@ -6,7 +6,7 @@
         "how": "outer", 
         "columns_to_map": {
             "taxon_id": "taxon_id",
-            "uniprot_ids": "uniprot_accessions"
+            "uniprot_ids": "primary_accession"
         }
     }
 }

--- a/src/integrators/integration_config.json
+++ b/src/integrators/integration_config.json
@@ -1,0 +1,12 @@
+{
+    "uniprot_covid19_parsed.tsv": {
+        "columns": [], 
+        "flag": true, 
+        "flag_label": "COVID-19 UniprotKB", 
+        "how": "outer", 
+        "columns_to_map": {
+            "taxon_id": "taxon_id",
+            "uniprot_ids": "uniprot_accessions"
+        }
+    }
+}

--- a/src/parsers/uniprot_parser.py
+++ b/src/parsers/uniprot_parser.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 def map_primary_uniprot_accession_to_ensembl(row):
     organism = row['organism_scientific_name'].replace(' ','_').lower()
-    accession = row['primaryAccession']
+    accession = row['primary_accession']
     URL = 'http://rest.ensembl.org/xrefs/symbol/{}/{}?content-type=application/json&object_type=gene'.format(
         organism,accession)
 
@@ -48,15 +48,15 @@ def main():
 
         # Pick simle pieces:
         parsed_entry = {
-            'primaryAccession': entry['primaryAccession'],
+            'primary_accession': entry['primaryAccession'],
             'uniprot_name': entry['uniProtkbId'],
             'organism_name': entry['organism']['commonName'],
-            'organism_id': entry['organism']['taxonId'],
+            'taxon_id': entry['organism']['taxonId'],
             'organism_scientific_name': entry['organism']['scientificName']
         }
         
         # Seconday accessions might not provided:
-        parsed_entry['secondaryAccessions'] = ','.join(entry['secondaryAccessions']) if 'secondaryAccessions' in entry else None
+        parsed_entry['secondary_accessions'] = ','.join(entry['secondaryAccessions']) if 'secondaryAccessions' in entry else None
         
         # Adding parsed data:
         parsed_entries.append(parsed_entry)
@@ -66,7 +66,11 @@ def main():
 
     # Mapping primary uniprot accessions to Ensembl gene id:
     print('[Info] Mapping primary Uniprot identifiers to Ensembl gene id...')
-    parsed_entries_df['gene_id'] = parsed_entries_df.apply(map_primary_uniprot_accession_to_ensembl, axis=1)
+    parsed_entries_df['ensembl_id'] = parsed_entries_df.apply(map_primary_uniprot_accession_to_ensembl, axis=1)
+
+    # Assing ID: if gene id available use that, if not use primary accession:
+    parsed_entries_df['id'] = parsed_entries_df.apply(lambda row: row['ensembl_id'] if row['ensembl_id'] else row['primary_accession'], axis=1)
+
 
     # Save file:
     parsed_entries_df.to_csv(outputFile, sep='\t', index=False)


### PR DESCRIPTION
This brach has a series of updates:

* Updated `README.md` describing folders and workflow.
* Updated Uniprot parser to accomodate the integrator script.
* Integrator script added (see details below)
* New Python module is added to requirements (`openpyxl `) to support saving results in excel format.
* `Makefile` updated to reflect the developed pipeline.

The integrator script works as follows:

```
usage: covid_data_integration.py [-h] -r REFERENCE -c CONFIG -i INPUTFOLDER -o
                                 OUTPUT

This script integrates COVID-19 related datasets into a single table.

optional arguments:
  -h, --help            show this help message and exit
  -r REFERENCE, --reference REFERENCE
                        File with the reference dataset.
  -c CONFIG, --config CONFIG
                        Configuration file describing integration recipes.
  -i INPUTFOLDER, --inputFolder INPUTFOLDER
                        Folder from which the integrated files are read.
  -o OUTPUT, --output OUTPUT
                        Output file name.
```