### PR TITLE
Ag drug table and integrator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ $(TARGETSINTEGRATED): parsers
 			-r $(ENSEMBLPARSED) \
 			-o $(TARGETSINTEGRATED) \
 			-i $(PREFORMATEDDIR)/targets \
-			-c $(SRCDIR)/integrators/integration_config.json
+			-c $(SRCDIR)/integrators/integration_config.json \
 			-e targets
 
 ##Files with drug info
@@ -290,5 +290,5 @@ $(DRUGSINTEGRATED): parsers
 			-r $(DRUGSPARSED) \
 			-o $(DRUGSINTEGRATED) \
 			-i $(PREFORMATEDDIR)/drugs \
-			-c $(SRCDIR)/integrators/integration_config.json
+			-c $(SRCDIR)/integrators/integration_config.json \
 			-e drugs

--- a/Makefile
+++ b/Makefile
@@ -102,28 +102,33 @@ HPA=$(RAWDIR)/hpa.json
 ######################################################
 
 ## Uniprot
-UNIPROTCOVIDPARSED=$(PREFORMATEDDIR)/uniprot_covid19_parsed.tsv
+UNIPROTCOVIDPARSED=$(PREFORMATEDDIR)/targets/uniprot_covid19_parsed.tsv
 ## OT
 OTDRUGEVIDENCE=$(PARSEDDIR)/ot_drug_evidence.tsv
-OTBASELINEPARSED=$(PREFORMATEDDIR)/ot_baseline_expression_per_anatomical_system.tsv
-OTSAFETYPARSED=$(PREFORMATEDDIR)/ot_target_safety.tsv
-OTTRACTABILITYPARSED=$(PREFORMATEDDIR)/ot_tractability_parsed.tsv
+OTBASELINEPARSED=$(PREFORMATEDDIR)/targets/ot_baseline_expression_per_anatomical_system.tsv
+OTSAFETYPARSED=$(PREFORMATEDDIR)/targets/ot_target_safety.tsv
+OTTRACTABILITYPARSED=$(PREFORMATEDDIR)/targets/ot_tractability_parsed.tsv
 ## Ensembl
 ENSEMBLPARSED=$(PARSEDDIR)/ensembl_parsed.json.gz
 ## Interactions
 COVIDCOMPLEXPARSED=$(PARSEDDIR)/complex_sars-cov-2_parsed.tsv
 INTACTCOVIDPARSED=$(PARSEDDIR)/IntAct_SARS-COV-2_interactions_parsed.tsv
 ## HPA
-HPAPREFORMATTED=$(PREFORMATEDDIR)/hpa_parsed.tsv
+HPAPREFORMATTED=$(PREFORMATEDDIR)/targets/hpa_parsed.tsv
 ## Drug info for target
-DRUGFORTARGETPARSED=$(PREFORMATEDDIR)/drug_fortarget_parsed.tsv
+DRUGFORTARGETPARSED=$(PREFORMATEDDIR)/targets/drug_fortarget_parsed.tsv
+## Drug info
+DRUGSPARSED=$(PARSEDDIR)/drug_info.tsv
+## Toy table of drugs in clinical trials for COVID-19
+DRUGSCOVID19TRIALSPARSED=$(PREFORMATEDDIR)/drugs/covid19_ct_test.tsv
 
 ###############################################################
 # PREFORMATED FILES - Files already formatted to be integrated
 ###############################################################
 
-COMPLEXPREFORMATTED=$(PREFORMATEDDIR)/complex_portal_preformatted.tsv
-INTEGRATED=$(RESULTDIR)/integrated_data.tsv
+COMPLEXPREFORMATTED=$(PREFORMATEDDIR)/targets/complex_portal_preformatted.tsv
+TARGETSINTEGRATED=$(RESULTDIR)/targets_integrated_data.tsv
+DRUGSINTEGRATED=$(RESULTDIR)/drugs_integrated_data.tsv
 
 #############################################################################
 
@@ -149,14 +154,15 @@ downloads: create-temp $(UNIPROTCOVIDFLATFILE) $(UNIPROTIDMAPPING) $(OTTRACTABIL
 ## TODO: OTDRUGEVIDENCE not yet fully parsed to agreed format.- just a placeholder
 parsers: $(OTDRUGEVIDENCE) $(UNIPROTCOVIDPARSED) $(COVIDCOMPLEXPARSED) $(INTACTCOVIDPARSED) \
 		$(ENSEMBLPARSED) $(OTBASELINEPARSED) $(HPAPREFORMATTED) $(DRUGFORTARGETPARSED) \
-		$(OTTRACTABILITYPARSED) $(OTSAFETYPARSED) $(COMPLEXPREFORMATTED)
+		$(OTTRACTABILITYPARSED) $(OTSAFETYPARSED) $(COMPLEXPREFORMATTED) $(DRUGSPARSED) $(DRUGSCOVID19TRIALSPARSED)
 
 # CREATES TEMPORARY DIRECTORY
 create-temp:
 	mkdir -p $(TEMPDIR)
 	mkdir -p $(RAWDIR)
 	mkdir -p $(PARSEDDIR)
-	mkdir -p $(PREFORMATEDDIR)
+	mkdir -p $(PREFORMATEDDIR)/targets
+	mkdir -p $(PREFORMATEDDIR)/drugs
 	mkdir -p $(RESULTDIR)
 
 ## Run integrator:
@@ -252,7 +258,7 @@ $(HPAPREFORMATTED): $(HPA)
 	$(PIPENV) run python $(SRCDIR)/parsers/hpa_parser.py -i $(HPA) -o $@
 
 $(DRUGFORTARGETPARSED): $(OTDRUGEVIDENCE)
-	$(PIPENV) run python $(SRCDIR)/parsers/target_druginfo_parser.py -i $(OTDRUGEVIDENCE) -o $@
+	$(PIPENV) run python $(SRCDIR)/parsers/target_druginfo_parser.py -i $(OTDRUGEVIDENCE) -o $@ -e target
 
 $(OTTRACTABILITYPARSED): $(OTTRACTABILITY)
 	$(PIPENV) run python $(SRCDIR)/parsers/tractability_parser.py -i $(OTTRACTABILITY) -o $@
@@ -260,13 +266,29 @@ $(OTTRACTABILITYPARSED): $(OTTRACTABILITY)
 $(OTSAFETYPARSED): $(OTKNOWNTARGETSAFETY) $(OTEXPERIMENTALTOXICITY) $(ENSEMBLPARSED)
 	$(PIPENV) run python $(SRCDIR)/parsers/safety_parser.py -k $(OTKNOWNTARGETSAFETY) -e $(OTEXPERIMENTALTOXICITY) -g $(ENSEMBLPARSED) -o $(OTSAFETYPARSED) -a
 
-##
-## Integrate:
-##
+$(DRUGSPARSED): $(OTDRUGEVIDENCE)
+	$(PIPENV) run python $(SRCDIR)/parsers/target_druginfo_parser.py -i $(OTDRUGEVIDENCE) -o $@ -e drug
 
+$(DRUGSCOVID19TRIALSPARSED): $(OTDRUGEVIDENCE)
+	$(PIPENV) run python $(SRCDIR)/parsers/target_druginfo_parser.py -i $(OTDRUGEVIDENCE) -o $@ -e covid19_trials
+
+##
+## Integrate files:
+##
+##Files with target info
 $(INTEGRATED): parsers
 		$(PIPENV) run python $(SRCDIR)/integrators/covid_data_integration.py \
 			-r $(ENSEMBLPARSED) \
-			-o $(INTEGRATED) \
-			-i $(PREFORMATEDDIR) \
+			-o $(TARGETSINTEGRATED) \
+			-i $(PREFORMATEDDIR)/targets \
 			-c $(SRCDIR)/integrators/integration_config.json
+			-e targets
+
+##Files with drug info
+$(INTEGRATED): parsers
+		$(PIPENV) run python $(SRCDIR)/integrators/covid_data_integration.py \
+			-r $(DRUGSPARSED) \
+			-o $(DRUGSINTEGRATED) \
+			-i $(PREFORMATEDDIR)/drugs \
+			-c $(SRCDIR)/integrators/integration_config.json
+			-e drugs

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ create-temp:
 	mkdir -p $(RESULTDIR)
 
 ## Run integrator:
-integrate: $(INTEGRATED)
+integrate: $(TARGETSINTEGRATED) $(DRUGSINTEGRATED)
 
 ##
 ## Fetching data:
@@ -276,7 +276,7 @@ $(DRUGSCOVID19TRIALSPARSED): $(OTDRUGEVIDENCE)
 ## Integrate files:
 ##
 ##Files with target info
-$(INTEGRATED): parsers
+$(TARGETSINTEGRATED): parsers
 		$(PIPENV) run python $(SRCDIR)/integrators/covid_data_integration.py \
 			-r $(ENSEMBLPARSED) \
 			-o $(TARGETSINTEGRATED) \
@@ -285,7 +285,7 @@ $(INTEGRATED): parsers
 			-e targets
 
 ##Files with drug info
-$(INTEGRATED): parsers
+$(DRUGSINTEGRATED): parsers
 		$(PIPENV) run python $(SRCDIR)/integrators/covid_data_integration.py \
 			-r $(DRUGSPARSED) \
 			-o $(DRUGSINTEGRATED) \

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -196,7 +196,6 @@ class DrugDataIntegrator(object):
 
 def main():
     # Parse command line arguments
-    parser = argparse.ArgumentParser()
     parser = argparse.ArgumentParser(description='This script integrates COVID-19 related datasets into a single table.')
 
     parser.add_argument('-r', '--reference', help='File with the reference dataset.', required=True, type=str)

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -32,7 +32,7 @@ def fetch_organism(tax_ids=[]):
         return None
 
 
-class DataIntegrator(object):
+class TargetDataIntegrator(object):
 
     def __init__(self, ensemblFile):
         
@@ -152,6 +152,46 @@ class DataIntegrator(object):
 
         # Update:
         self.ensembl_df = merged
+
+
+class DrugDataIntegrator(object):
+
+    def __init__(self, drugFile):
+
+        self.drug_df = pd.read_csv(drugFile, sep='\t', header=0)
+
+        print('[Info] Reading data complete. Number of drugs: {}'.format(len(self.drug_df.index)))
+        print('[Info] Processing data...')
+
+    def add_data(self, data_df, parameters):
+        """
+        Adding new drug data to the integrator
+        """
+        ##
+        ## Checking merge parameters
+        ##
+
+        # Checking columns of intereset:
+        columns = parameters['columns'] if 'columns' in parameters else []
+
+        # How to join:
+        how = parameters['how'] if 'how' in parameters else 'left'
+
+        ##
+        ## Join data:
+        ##
+
+        merged = self.drug_df.merge(data_df, how=how, on='id')
+        self.drug_df = merged
+
+    def get_integrated_data(self):
+        return self.drug_df
+
+    def save_integrated(self, file_name='test.tsv'):
+        if '.tsv' in file_name:
+            self.drug_df.to_csv(file_name, sep='\t', index=False)
+        if '.xlsx' in file_name:
+            self.drug_df.to_excel(file_name, index=False)
 
 
 def main():

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -13,6 +13,17 @@ def get_target_druginfo(df):
 
     return result
 
+def get_drug_info(df):
+    """ Get max phase per drug"""
+
+    result = df \
+        .groupby('drug_id').agg(
+        max_phase=('phase', 'max')
+        ) \
+        .reset_index()
+
+    return result
+
 def main():
     
     # Parse command line arguments
@@ -21,12 +32,14 @@ def main():
 
     parser.add_argument('-i', '--input', help='OT drug evidence table', required=True, type=str)
     parser.add_argument('-o', '--output', help='Output file name.', required=True, type=str)
+    parser.add_argument('-e', '--entity', help='Entity type to extract info for.', required=True, choices=['target', 'drug'])
 
     args = parser.parse_args()
 
     # Get parameters:
     input_file = args.input
     output_file = args.output
+    entity = args.entity
 
     df = pd.read_csv(input_file, \
                 sep = "\t", \
@@ -39,7 +52,10 @@ def main():
     #     ) \
     #     .reset_index()
 
-    result = get_target_druginfo(df)
+    if entity == "target":
+        result = get_target_druginfo(df)
+    else:
+        result = get_drug_info(df)
 
     result.to_csv(output_file, sep='\t', index=False)
 

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -23,6 +23,8 @@ def get_drug_info(df):
         ) \
         .reset_index()
 
+    # Rename drug_id to id
+    result.rename(columns={'drug_id': 'id'} , inplace= True)
     return result
 
 def get_toy_covid_ct_table(df):

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -1,6 +1,18 @@
 import argparse
 import pandas as pd 
 
+def get_target_druginfo(df):
+    """ Get number of drugs per target and max phase"""
+
+    result = df \
+        .groupby('id').agg(
+        max_phase=('phase', 'max'),
+        drugs_in_clinic=('drug_id', 'nunique')
+        ) \
+        .reset_index()
+
+    return result
+
 def main():
     
     # Parse command line arguments
@@ -20,12 +32,12 @@ def main():
                 sep = "\t", \
                 names = ["id", "disease_id", "drug_id", "phase", "moa", "drug_name"])
 
-    result = df \
-        .groupby('id').agg(
-            max_phase = ('phase', 'max'),
-            drugs_in_clinic = ('drug_id', 'nunique')
-        ) \
-        .reset_index()
+    # result = df \
+    #     .groupby('id').agg(
+    #         max_phase = ('phase', 'max'),
+    #         drugs_in_clinic = ('drug_id', 'nunique')
+    #     ) \
+    #     .reset_index()
 
     result.to_csv(output_file, sep='\t', index=False)
 

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -39,6 +39,8 @@ def main():
     #     ) \
     #     .reset_index()
 
+    result = get_target_druginfo(df)
+
     result.to_csv(output_file, sep='\t', index=False)
 
 if __name__ == '__main__':

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -27,7 +27,6 @@ def get_drug_info(df):
 def main():
     
     # Parse command line arguments
-    parser = argparse.ArgumentParser()
     parser = argparse.ArgumentParser(description='Parse information from OT drug evidence and aggregates info at the target level.')
 
     parser.add_argument('-i', '--input', help='OT drug evidence table', required=True, type=str)
@@ -44,13 +43,6 @@ def main():
     df = pd.read_csv(input_file, \
                 sep = "\t", \
                 names = ["id", "disease_id", "drug_id", "phase", "moa", "drug_name"])
-
-    # result = df \
-    #     .groupby('id').agg(
-    #         max_phase = ('phase', 'max'),
-    #         drugs_in_clinic = ('drug_id', 'nunique')
-    #     ) \
-    #     .reset_index()
 
     if entity == "target":
         result = get_target_druginfo(df)

--- a/src/parsers/target_druginfo_parser.py
+++ b/src/parsers/target_druginfo_parser.py
@@ -1,5 +1,6 @@
 import argparse
-import pandas as pd 
+import pandas as pd
+import numpy as np
 
 def get_target_druginfo(df):
     """ Get number of drugs per target and max phase"""
@@ -24,6 +25,26 @@ def get_drug_info(df):
 
     return result
 
+def get_toy_covid_ct_table(df):
+    """ Create an example table of drugs in clinical trials for COVID-19
+    It will select 500 random drugs and assign them a random phase"""
+
+    toy_covid_ct_list = []
+
+    drugs = df.drug_id.unique()
+    random_drugs = np.random.choice(drugs, 500, replace=False)
+
+    for drug in drugs:
+        if drug in random_drugs:
+            covid19_ct = True
+            covid19_ct_phase = int(np.random.choice([1,2,3,4], 1))
+        else:
+            covid19_ct = False
+            covid19_ct_phase = None
+        toy_covid_ct_list.append(dict(id=drug, has_covid19_trial=covid19_ct, covid19_trial_phase=covid19_ct_phase))
+
+    return pd.DataFrame(toy_covid_ct_list)
+
 def main():
     
     # Parse command line arguments
@@ -31,7 +52,7 @@ def main():
 
     parser.add_argument('-i', '--input', help='OT drug evidence table', required=True, type=str)
     parser.add_argument('-o', '--output', help='Output file name.', required=True, type=str)
-    parser.add_argument('-e', '--entity', help='Entity type to extract info for.', required=True, choices=['target', 'drug'])
+    parser.add_argument('-e', '--entity', help='Entity type to extract info for.', required=True, choices=['target', 'drug', 'covid19_trials'])
 
     args = parser.parse_args()
 
@@ -46,8 +67,12 @@ def main():
 
     if entity == "target":
         result = get_target_druginfo(df)
-    else:
+    elif entity == "drug":
         result = get_drug_info(df)
+    else:
+        result = get_toy_covid_ct_table(df)
+        # Convert clinical trials phase column to an integer format that supports missing values
+        result['covid19_trial_phase'] = result['covid19_trial_phase'].astype('Int64')
 
     result.to_csv(output_file, sep='\t', index=False)
 


### PR DESCRIPTION
- Create a table of max phase per drug from ChEMBL evidence file
- Add new class to integrator to be able to merge files with drug information
- Update Makefile to divide preformated_tables directory into `targets` and `drugs`

Current implementation includes the creation of a toy table that represents drugs in clinical trials for COVID-19