### PR TITLE
adding filter columns

### DIFF
--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -153,6 +153,32 @@ class TargetDataIntegrator(object):
         # Update:
         self.ensembl_df = merged
 
+    def add_filter_columns(self):
+        integrated_df = self.ensembl_df
+
+        ##
+        ## Filter No1: Any of the networks OR uniprot implicated.
+        ##
+        integrated_df['FILTER_network'] =  (
+            integrated_df['COVID-19 UniprotKB'] | 
+            (~ integrated_df['COVID_complex_names'].isna()) | 
+            (~ integrated_df['Covid_direct_interactions'].isna()) | 
+            (~ integrated_df['Covid_indirect_interactions'].isna()) | 
+            (integrated_df['Implicated_in_viral_infection'] == True)
+        )
+
+
+        ##
+        ## Filter No2: Any networks AND Phase3 or 4 trial
+        ##
+        integrated_df['FILTER_network+drug'] = (
+            integrated_df['FILTER_network'] &
+            integrated_df['max_phase'] > 2
+        )
+
+        # Update dataframe:
+        self.ensembl_df = integrated_df
+
 
 class DrugDataIntegrator(object):
 
@@ -248,9 +274,10 @@ def main():
         # Integrating:
         integrator_obj.add_data(data_df, parameters)
 
-    # Map taxonomy to species:
+    # Map taxonomy to species and apply filters:
     if entity_type == "targets":
         integrator_obj.map_taxonomy()
+        integrator_obj.add_filter_columns()
 
     # Save data:
     integrator_obj.save_integrated(output_file)

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -160,7 +160,7 @@ class TargetDataIntegrator(object):
         ## Filter No1: Any of the networks OR uniprot implicated.
         ##
         integrated_df['FILTER_network'] =  (
-            integrated_df['COVID-19 UniprotKB'] | 
+            (integrated_df['COVID-19 UniprotKB']) | 
             (~ integrated_df['COVID_complex_names'].isna()) | 
             (~ integrated_df['Covid_direct_interactions'].isna()) | 
             (~ integrated_df['Covid_indirect_interactions'].isna()) | 
@@ -172,8 +172,8 @@ class TargetDataIntegrator(object):
         ## Filter No2: Any networks AND Phase3 or 4 trial
         ##
         integrated_df['FILTER_network+drug'] = (
-            integrated_df['FILTER_network'] &
-            integrated_df['max_phase'] > 2
+            (integrated_df['FILTER_network']) &
+            (integrated_df['max_phase'] > 2)
         )
 
         # Update dataframe:


### PR DESCRIPTION
Two extra boolean columns are added to the integrated table representing two different set of filters.

**FILTER_network**
* If a target is in the uniprot covid file
* OR a target is in the Intact covid file
* OR a target is a second degree interactor of covid protein

**FILTER_network+drug**
* If a target is selected by the above filter
* AND phase 3 or phase 4 drug is available (based on `max_phase` column)