### PR TITLE
resolution of non-uniqueness in the intact file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ MOA_FILE=$(DATADIR)/dt_pairs_moa_chembl.txt
 # PARSED FILES - Files with some intermediate parsing
 ######################################################
 
-## Uniprot
-UNIPROTCOVIDPARSED=$(PREFORMATEDDIR)/targets/uniprot_covid19_parsed.tsv
+## Uniprot - Excalamation mark is added to make sure it is integrated first
+UNIPROTCOVIDPARSED=$(PREFORMATEDDIR)/targets/!uniprot_covid19_parsed.tsv
 ## OT
 OTDRUGEVIDENCE=$(PARSEDDIR)/ot_drug_evidence.tsv
 OTBASELINEPARSED=$(PREFORMATEDDIR)/targets/ot_baseline_expression_per_anatomical_system.tsv
@@ -242,7 +242,7 @@ $(ENSEMBLPARSED) $(UNIPROT2ENSEMBLDRAFT): $(ENSEMBL)
 	$(PIPENV) run python $(SRCDIR)/parsers/ensembl_parser.py -i $(ENSEMBL) -o $(ENSEMBLPARSED) -m $(UNIPROT2ENSEMBLDRAFT)
 
 $(INTACTCOVIDPARSED): $(INTACTCOVID) $(UNIPROTIDMAPPING) $(INTACTHUMAN)
-	$(PIPENV) run python $(SRCDIR)/parsers/intact_parser.py -i $(INTACTCOVID) -o $@ -m  $(UNIPROTIDMAPPING) -f $(INTACTHUMAN)
+	$(PIPENV) run python $(SRCDIR)/parsers/intact_parser.py -i $(INTACTCOVID) -o $@ -m  $(UNIPROT2ENSEMBL) -f $(INTACTHUMAN)
 
 $(OTBASELINEPARSED): $(OTBASELINE) $(OTBASELINETISSUEMAP)
 	$(PIPENV) run python $(SRCDIR)/parsers/baseline_parser.py -i $(OTBASELINE) -m $(OTBASELINETISSUEMAP) -o $@

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -247,6 +247,7 @@ def main():
 
     # Reading files from the preformatted folder:
     preformatted_files = [f for f in listdir(input_folder) if isfile(join(input_folder, f))]
+    preformatted_files.sort()   
     print('[Info] Integrating the following files:\n\t{}'.format('\n\t'.join(preformatted_files)))
 
     # 1. Generate first table.
@@ -272,6 +273,10 @@ def main():
         # Testing if table has id:
         if 'id' not in data_df.columns.tolist():
             raise ValueError('The table must have \'id\' column to join.')
+
+        # Skipping data if the id column is not unique:
+        if len(data_df) != len(data_df['id'].unique()):
+            print('[Warning] The \'id\' column in {} file is not unique!'.format(preformatted_file))
 
         # Read or generate join parameters:
         parameters = config_data[preformatted_file] if preformatted_file in config_data else {'columns':data_df.columns.tolist()}

--- a/src/integrators/integration_config.json
+++ b/src/integrators/integration_config.json
@@ -1,5 +1,5 @@
 {
-    "uniprot_covid19_parsed.tsv": {
+    "!uniprot_covid19_parsed.tsv": {
         "columns": [], 
         "flag": true, 
         "flag_label": "COVID-19 UniprotKB", 

--- a/src/parsers/Ensembl-Uniprot_map_generator.py
+++ b/src/parsers/Ensembl-Uniprot_map_generator.py
@@ -27,9 +27,12 @@ if __name__ == '__main__':
 
     ## Report input data:
     print('[Info] Report on the Ensembl mapping file:')
+    print('[Info] Dropping non-Ensembl gene IDs...')
+    ensembl_map_df = ensembl_map_df.loc[ensembl_map_df.ensembl_id.str.match('ENSG.+')]
     print('[Info] Number of rows: {}'.format(len(ensembl_map_df)))
     print('[Info] Number of unique genes: {}'.format(len(ensembl_map_df.ensembl_id.unique())))
     print('[Info] Number of unique proteins: {}'.format(len(ensembl_map_df.uniprot_id.unique())))
+
     print('')
     print('[Info] Report on the Uniprot mapping file:')
     print('[Info] Number of unique proteins: {}'.format(len(uniprot_map_df.uniprot.unique())))


### PR DESCRIPTION
* Non-uniqueness of the gene-id column in the pre-processed Intact file is sorted.
* Pre-processed Uniprot file is renamed from `uniprot_covid19_parsed.tsv` to `!uniprot_covid19_parsed.tsv` to ensure this is the first integrated dataset.