### PR TITLE
Json dump fix

### DIFF
--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -331,8 +331,11 @@ def main():
     if entity_type == "targets":
         integrator_obj.map_taxonomy()
         integrator_obj.add_filter_columns()
-        # Formst target table as proper JSON
+        # Format target table as proper JSON
         integrator_obj.fix_json()
+
+    # Save data in tsv format
+    integrator_obj.save_integrated(output_file)
 
     # Save data in json format:
     if 'tsv' in output_file:

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -128,7 +128,9 @@ class TargetDataIntegrator(object):
         return self.ensembl_df
     
     
-    def fix_json(self, df):
+    def fix_json(self):
+        df = self.ensembl_df
+
         # Columns to fix format:
         columns_to_json_load = []
 
@@ -154,7 +156,8 @@ class TargetDataIntegrator(object):
             # Update column:
             df[col] = values
 
-        return df
+        # Update dataframe:
+        self.ensembl_df = df
 
     def save_integrated(self, file_name='test.tsv'):
         integrated = self.ensembl_df.copy()
@@ -167,7 +170,6 @@ class TargetDataIntegrator(object):
         if '.xlsx' in file_name:
             integrated.to_excel(file_name, index=False)
         if '.json' in file_name:
-            integrated = self.fix_json(integrated)
             integrated.to_json(file_name, lines=True,orient='records',compression='infer')
 
     def map_taxonomy(self):
@@ -331,6 +333,7 @@ def main():
         integrator_obj.add_filter_columns()
 
     # Save data in tsv format:
+    integrator_obj.fix_json()
     integrator_obj.save_integrated(output_file)
 
     # Save data in json format:

--- a/src/integrators/covid_data_integration.py
+++ b/src/integrators/covid_data_integration.py
@@ -331,10 +331,8 @@ def main():
     if entity_type == "targets":
         integrator_obj.map_taxonomy()
         integrator_obj.add_filter_columns()
-
-    # Save data in tsv format:
-    integrator_obj.fix_json()
-    integrator_obj.save_integrated(output_file)
+        # Formst target table as proper JSON
+        integrator_obj.fix_json()
 
     # Save data in json format:
     if 'tsv' in output_file:

--- a/src/parsers/baseline_parser.py
+++ b/src/parsers/baseline_parser.py
@@ -82,7 +82,7 @@ def parse_baseline(baseline_filename, tissue_mapping, output_filename):
 
     # Save columns that contain lists as valid JSON strings
     for column in expression_per_anatomical_systems_df.filter(regex="_list").columns:
-        expression_per_anatomical_systems_df[column] = expression_per_anatomical_systems_df.apply(lambda x: json.dumps(x) if isinstance(x, list) else x)
+        expression_per_anatomical_systems_df[column] = expression_per_anatomical_systems_df[column].apply(lambda x: json.dumps(x) if isinstance(x, list) else x)
 
     # Write to file
     expression_per_anatomical_systems_df.to_csv(output_filename, sep='\t', index=False)

--- a/src/parsers/baseline_parser.py
+++ b/src/parsers/baseline_parser.py
@@ -80,6 +80,10 @@ def parse_baseline(baseline_filename, tissue_mapping, output_filename):
             empty_columns.append(column.replace("is_expressed", "expressed_tissue_list"))
     expression_per_anatomical_systems_df.drop(columns=empty_columns, inplace=True)
 
+    # Save columns that contain lists as valid JSON strings
+    for column in expression_per_anatomical_systems_df.filter(regex="_list").columns:
+        expression_per_anatomical_systems_df[column] = expression_per_anatomical_systems_df.apply(lambda x: json.dumps(x) if isinstance(x, list) else x)
+
     # Write to file
     expression_per_anatomical_systems_df.to_csv(output_filename, sep='\t', index=False)
 

--- a/src/parsers/hpa_parser.py
+++ b/src/parsers/hpa_parser.py
@@ -31,8 +31,12 @@ def main():
             parsed_entry['hpa_rna_specific_tissues'] = list(entry['RNA tissue specific NX'].keys()) if entry['RNA tissue specific NX'] is not None  else None
             parsed_entries.append(parsed_entry)
 
-    # Open output gzip file.
     parsed_entries_df = pd.DataFrame(parsed_entries)
+
+    # save columns in JSON format:
+    for column in ['hpa_rna_specific_tissues', 'hpa_subcellular_location']:
+        parsed_entries_df[column] = parsed_entries_df[column].apply(lambda x: json.dumps(x) if isinstance(x, list) else x)
+
     # Save file:
     parsed_entries_df.to_csv(output_file, sep='\t', index=False)
 

--- a/src/parsers/intact_parser.py
+++ b/src/parsers/intact_parser.py
@@ -143,7 +143,7 @@ def pool_arrays(s):
                 x.add(a)
     
     if len(x) > 0:
-        return list(x)
+        return json.dumps(list(x))
     else:
         return np.nan
 
@@ -160,20 +160,19 @@ def map_to_ensembl_gene_id(merged, id_map_df):
     # Collapsing data:
     collapsed = []
     for gene_id, group in merged.groupby(['id']):
-        if len(group) == 1:
-            collapsed += group.to_dict(orient='record')
-        else:
-            try:
-                collapsed.append({
-                    'Implicated_in_viral_infection':group.Implicated_in_viral_infection.any(),
-                    'id':gene_id,
-                    'Covid_direct_interactions': pool_arrays(group.Covid_direct_interactions),
-                    'Covid_indirect_interactions': pool_arrays(group.Covid_indirect_interactions)
-                })
-            except:
-                print(group)
-                raise
+        try:
+            collapsed.append({
+                'Implicated_in_viral_infection':group.Implicated_in_viral_infection.any(),
+                'id':gene_id,
+                'Covid_direct_interactions': pool_arrays(group.Covid_direct_interactions),
+                'Covid_indirect_interactions': pool_arrays(group.Covid_indirect_interactions)
+            })
+        except:
+            print(group)
+            raise
     collapsed_df = pd.DataFrame(collapsed)
+    print(type(collapsed[2]['Covid_indirect_interactions']))
+    print(collapsed[2]['Covid_indirect_interactions'])
     return collapsed_df
 
 

--- a/src/parsers/safety_parser.py
+++ b/src/parsers/safety_parser.py
@@ -120,6 +120,11 @@ class Safety():
         # Write to tsv file
         safety_df = pd.DataFrame.from_dict(self.target_safety_info, orient='index', columns=['name', 'has_safety_risk', 'safety_info_source', 'safety_organs_systems_affected'])
         safety_df.index.name = "id"
+
+        # save columns in JSON format:
+        for column in ['safety_info_source', 'safety_organs_systems_affected']:
+            safety_df[column] = safety_df[column].apply(lambda x: json.dumps(x) if isinstance(x, list) else x)
+
         safety_df.to_csv(output_filename, sep='\t')
 
 def main():


### PR DESCRIPTION
The modifications in this branch enable saving a properly formatted JSON documents, where the table values can also be arrays as well.

**Modified files:**

* `covid_data_integration.py` - looks through the integrated table and if founds array like strings, tries to load it as JSON.
* `hpa_parser.py` - columns that potentially contain arrays, are saved as JSON formatted strings.
* `intact_parser.py` - columns that potentially contain arrays, are saved as JSON formatted strings.
* `safety_parser.py` - columns that potentially contain arrays, are saved as JSON formatted strings.