### PR TITLE
data update: opentargets, intact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,29 +9,29 @@
 #################################
 
 # Uniprot covid19 flat file
-UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/download?format=json&query=%2A"
+UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/stream?format=json&query=%2A"
 UNIPROTIDMAPPINGURL=ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
 
 # OT files
-OTTRACTABILITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.06/input/annotation-files/tractability_buckets-2020-05-14.tsv
-OTKNOWNTARGETSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.06/input/annotation-files/known_target_safety-2020-06-01.json
-OTEXPERIMENTALTOXICITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.06/input/annotation-files/experimental-toxicity-2020-04-07.tsv
-OTBASELINEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.06/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
+OTTRACTABILITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/tractability_buckets-2020-08-14.tsv
+OTKNOWNTARGETSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/known_target_safety-2020-09-02.json
+OTEXPERIMENTALTOXICITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/experimental-toxicity-2020-04-07.tsv
+OTBASELINEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
 OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json
-OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.06/output/20.06_evidence_data.json.gz
-OTTARGETLISTBUCKET='https://storage.googleapis.com/open-targets-data-releases/20.06/output/20.06_target_list.csv.gz'
+OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/output/20.09_evidence_data.json.gz
+OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/output/20.09_target_list.csv.gz
 
 # Ensembl json
 ENSEMBLURL = ftp://ftp.ensembl.org/pub/release-100/json/homo_sapiens/homo_sapiens.json
 
 # COVID complex file:
-COVIDCOMPLEXURL=http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/current/complextab/sars-cov-2.tsv
+COVIDCOMPLEXURL=http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/2020-09-25/complextab/sars-cov-2.tsv
 
 # IntAct COVID related interaction query:
 INTACTCOVIDURL="https://www.ebi.ac.uk/intact/export?format=mitab_27&query=annot%3A%22dataset%3ACoronavirus%22&negative=false&spoke=false&ontology=false&sort=intact-miscore&asc=false"
 
 # Full human intact data:
-INTACTHUMANURL='ftp://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/current/data/interactor_pair_interactions.json'
+INTACTHUMANURL='ftp://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/2020-10-05/data/interactor_pair_interactions.json'
 
 # HPA
 HPAURL=https://www.proteinatlas.org/download/proteinatlas.json.gz

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 COVID data integration report
 ================
-16 July, 2020
+09 October, 2020
 
 # Data available
 
@@ -23,37 +23,37 @@ df %>%
 
 | variable                                     | Category                         | targets |
 | :------------------------------------------- | :------------------------------- | ------: |
-| scientificName                               | TARGET INFO                      |   27625 |
-| name                                         | TARGET INFO                      |   27596 |
-| biotype                                      | TARGET INFO                      |   27596 |
-| description                                  | TARGET INFO                      |   27406 |
-| uniprot\_ids                                 | TARGET INFO                      |   19896 |
-| COVID-19 UniprotKB                           | TARGET INFO                      |      38 |
-| FILTER\_network                              | FILTERS                          |    4760 |
-| FILTER\_network+drug                         | FILTERS                          |     220 |
-| FILTER\_network+covid\_tests                 | FILTERS                          |    5188 |
-| Covid\_direct\_interactions                  | PROTEIN INTERACTIONS             |     678 |
-| Covid\_indirect\_interactions                | PROTEIN INTERACTIONS             |    4304 |
-| Implicated\_in\_viral\_infection             | PROTEIN INTERACTIONS             |     850 |
-| max\_phase                                   | DRUGS FOR TARGET                 |    1183 |
-| drugs\_in\_clinic                            | DRUGS FOR TARGET                 |    1183 |
+| scientificName                               | TARGET INFO                      |   27639 |
+| name                                         | TARGET INFO                      |   27610 |
+| biotype                                      | TARGET INFO                      |   27610 |
+| description                                  | TARGET INFO                      |   27418 |
+| uniprot\_ids                                 | TARGET INFO                      |   19872 |
+| COVID-19 UniprotKB                           | TARGET INFO                      |      57 |
+| FILTER\_network                              | FILTERS                          |    7639 |
+| FILTER\_network+drug                         | FILTERS                          |     395 |
+| FILTER\_network+covid\_tests                 | FILTERS                          |    7961 |
+| Covid\_direct\_interactions                  | PROTEIN INTERACTIONS             |    1653 |
+| Covid\_indirect\_interactions                | PROTEIN INTERACTIONS             |    6781 |
+| Implicated\_in\_viral\_infection             | PROTEIN INTERACTIONS             |    1904 |
+| max\_phase                                   | DRUGS FOR TARGET                 |    1191 |
+| drugs\_in\_clinic                            | DRUGS FOR TARGET                 |    1191 |
 | has\_invitro\_covid\_activity                | DRUGS FOR TARGET                 |     522 |
 | invitro\_covid\_activity                     | DRUGS FOR TARGET                 |     522 |
 | has\_drug\_in\_covid\_trials                 | DRUGS FOR TARGET                 |      99 |
-| hpa\_subcellular\_location                   | BASELINE GENE EXPRESSION         |   12301 |
-| hpa\_rna\_tissue\_distribution               | BASELINE GENE EXPRESSION         |   19359 |
-| hpa\_rna\_tissue\_specificity                | BASELINE GENE EXPRESSION         |   19359 |
-| hpa\_rna\_specific\_tissues                  | BASELINE GENE EXPRESSION         |   10844 |
-| respiratory\_system\_is\_expressed           | BASELINE GENE EXPRESSION         |   20039 |
-| respiratory\_system\_expressed\_tissue\_list | BASELINE GENE EXPRESSION         |   26492 |
-| immune\_system\_is\_expressed                | BASELINE GENE EXPRESSION         |   23450 |
-| immune\_system\_expressed\_tissue\_list      | BASELINE GENE EXPRESSION         |   26492 |
-| is\_abundance\_reg\_on\_covid                | COVID-19 HOST PROTEIN REGULATION |    1149 |
-| abundance\_reg\_on\_covid                    | COVID-19 HOST PROTEIN REGULATION |    1149 |
-| Tractability\_Top\_bucket\_(sm)              | TARGET TRACTABILITY              |    4976 |
-| Tractability\_Top\_bucket\_(ab)              | TARGET TRACTABILITY              |    8867 |
-| Tractability\_Top\_bucket\_(other)           | TARGET TRACTABILITY              |     184 |
+| hpa\_subcellular\_location                   | BASELINE GENE EXPRESSION         |   12297 |
+| hpa\_rna\_tissue\_distribution               | BASELINE GENE EXPRESSION         |   19347 |
+| hpa\_rna\_tissue\_specificity                | BASELINE GENE EXPRESSION         |   19347 |
+| hpa\_rna\_specific\_tissues                  | BASELINE GENE EXPRESSION         |   10838 |
+| respiratory\_system\_is\_expressed           | BASELINE GENE EXPRESSION         |   20124 |
+| respiratory\_system\_expressed\_tissue\_list | BASELINE GENE EXPRESSION         |   26021 |
+| immune\_system\_is\_expressed                | BASELINE GENE EXPRESSION         |   22765 |
+| immune\_system\_expressed\_tissue\_list      | BASELINE GENE EXPRESSION         |   26021 |
+| is\_abundance\_reg\_on\_covid                | COVID-19 HOST PROTEIN REGULATION |    1147 |
+| abundance\_reg\_on\_covid                    | COVID-19 HOST PROTEIN REGULATION |    1147 |
+| Tractability\_Top\_bucket\_(sm)              | TARGET TRACTABILITY              |    5035 |
+| Tractability\_Top\_bucket\_(ab)              | TARGET TRACTABILITY              |    9882 |
+| Tractability\_Top\_bucket\_(other)           | TARGET TRACTABILITY              |     215 |
 | has\_safety\_risk                            | TARGET SAFETY                    |     439 |
 | safety\_info\_source                         | TARGET SAFETY                    |     439 |
 | safety\_organs\_systems\_affected            | TARGET SAFETY                    |     193 |
-| covid\_literature                            | LITERATURE                       |     122 |
+| covid\_literature                            | LITERATURE                       |     264 |

--- a/src/parsers/uniprot_parser.py
+++ b/src/parsers/uniprot_parser.py
@@ -12,7 +12,7 @@ def map_primary_uniprot_accession_to_ensembl(row):
     URL = 'http://rest.ensembl.org/xrefs/symbol/{}/{}?content-type=application/json&object_type=gene'.format(
         organism,accession)
 
-    response = requests.get(URL).json()
+    response = requests.get(URL, verify=False).json()
 
     if 'error' in response:
         print('[Warning] Could not find Ensembl gene ID to {}'.format(accession))


### PR DESCRIPTION
**Data updates**:

* Uniprot covid url update
* OpenTargets data update to 20.09
* Moving to the new Intact release for human interactions and covid complexes. (links now contain the data version)


**Changes in the result summary**:

* Slightly higher number of targets
* Increased numbers for all covid related fields
