### PR TITLE
data update: OT 21.02, intact, ensembl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/stream?f
 UNIPROTIDMAPPINGURL=ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
 
 # OT files
-OTTRACTABILITYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/tractability_buckets-2021-01-12.tsv
+OTTRACTABILITYBUCKET="https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/tractability_buckets-2021-01-12.tsv"
 OTKNOWNTARGETSAFETYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/known_target_safety-2021-02-09.json
 OTEXPERIMENTALTOXICITYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/experimental-toxicity-2020-04-07.tsv
 OTBASELINEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
-OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json
+OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json #func
 OTEVIDENCEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/output/21.02_evidence_data.json.gz
-OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_target_list.json.gz
+OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_target_list.csv.gz
 
 # Ensembl json
 ENSEMBLURL = ftp://ftp.ensembl.org/pub/release-102/json/homo_sapiens/homo_sapiens.json

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/stream?f
 UNIPROTIDMAPPINGURL=ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
 
 # OT files
-OTTRACTABILITYBUCKET="https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/tractability_buckets-2021-01-12.tsv"
-OTKNOWNTARGETSAFETYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/known_target_safety-2021-02-09.json
-OTEXPERIMENTALTOXICITYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/experimental-toxicity-2020-04-07.tsv
-OTBASELINEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
+OTTRACTABILITYBUCKET="https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/tractability_buckets-2021-01-12.tsv"
+OTKNOWNTARGETSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/known_target_safety-2021-02-09.json
+OTEXPERIMENTALTOXICITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/experimental-toxicity-2020-04-07.tsv
+OTBASELINEBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
 OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json #func
-OTEVIDENCEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/output/21.02_evidence_data.json.gz
+OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_evidence_data.json.gz
 OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_target_list.csv.gz
 
 # Ensembl json

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OTTRACTABILITYBUCKET="https://storage.googleapis.com/open-targets-data-releases/
 OTKNOWNTARGETSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/known_target_safety-2021-02-09.json
 OTEXPERIMENTALTOXICITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/experimental-toxicity-2020-04-07.tsv
 OTBASELINEBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
-OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json #func
+OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json
 OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_evidence_data.json.gz
 OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_target_list.csv.gz
 

--- a/Makefile
+++ b/Makefile
@@ -13,25 +13,25 @@ UNIPROTCOVIDQUERY="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/stream?f
 UNIPROTIDMAPPINGURL=ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/by_organism/HUMAN_9606_idmapping.dat.gz
 
 # OT files
-OTTRACTABILITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/tractability_buckets-2020-08-14.tsv
-OTKNOWNTARGETSAFETYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/known_target_safety-2020-09-02.json
-OTEXPERIMENTALTOXICITYBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/experimental-toxicity-2020-04-07.tsv
-OTBASELINEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
+OTTRACTABILITYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/tractability_buckets-2021-01-12.tsv
+OTKNOWNTARGETSAFETYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/known_target_safety-2021-02-09.json
+OTEXPERIMENTALTOXICITYBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/experimental-toxicity-2020-04-07.tsv
+OTBASELINEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/input/annotation-files/baseline_expression_counts-2020-05-07.tsv
 OTBASELINETISSUEMAPGITHUB=https://raw.githubusercontent.com/opentargets/expression_hierarchy/master/process/map_with_efos.json
-OTEVIDENCEBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/output/20.09_evidence_data.json.gz
-OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/20.09/output/20.09_target_list.csv.gz
+OTEVIDENCEBUCKET=https://storage.cloud.google.com/open-targets-data-releases/21.02/output/21.02_evidence_data.json.gz
+OTTARGETLISTBUCKET=https://storage.googleapis.com/open-targets-data-releases/21.02/output/21.02_target_list.json.gz
 
 # Ensembl json
-ENSEMBLURL = ftp://ftp.ensembl.org/pub/release-100/json/homo_sapiens/homo_sapiens.json
+ENSEMBLURL = ftp://ftp.ensembl.org/pub/release-102/json/homo_sapiens/homo_sapiens.json
 
 # COVID complex file:
-COVIDCOMPLEXURL=http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/2020-09-25/complextab/sars-cov-2.tsv
+COVIDCOMPLEXURL=http://ftp.ebi.ac.uk/pub/databases/IntAct/complex/2020-11-05/complextab/sars-cov-2.tsv
 
 # IntAct COVID related interaction query:
 INTACTCOVIDURL="https://www.ebi.ac.uk/intact/export?format=mitab_27&query=annot%3A%22dataset%3ACoronavirus%22&negative=false&spoke=false&ontology=false&sort=intact-miscore&asc=false"
 
 # Full human intact data:
-INTACTHUMANURL='ftp://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/2020-10-05/data/interactor_pair_interactions.json'
+INTACTHUMANURL='ftp://ftp.ebi.ac.uk/pub/databases/intact/various/ot_graphdb/2021-01-18/data/interactor_pair_interactions.json'
 
 # HPA
 HPAURL=https://www.proteinatlas.org/download/proteinatlas.json.gz

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 COVID data integration report
 ================
-09 October, 2020
+15 February, 2021
 
 # Data available
 
@@ -22,38 +22,38 @@ df %>%
     ## Warning: Unknown levels in `f`: ensembl_id, drugs_in_covid_trials
 
 | variable                                     | Category                         | targets |
-| :------------------------------------------- | :------------------------------- | ------: |
-| scientificName                               | TARGET INFO                      |   27639 |
-| name                                         | TARGET INFO                      |   27610 |
-| biotype                                      | TARGET INFO                      |   27610 |
-| description                                  | TARGET INFO                      |   27418 |
-| uniprot\_ids                                 | TARGET INFO                      |   19872 |
-| COVID-19 UniprotKB                           | TARGET INFO                      |      57 |
-| FILTER\_network                              | FILTERS                          |    7639 |
-| FILTER\_network+drug                         | FILTERS                          |     395 |
-| FILTER\_network+covid\_tests                 | FILTERS                          |    7961 |
-| Covid\_direct\_interactions                  | PROTEIN INTERACTIONS             |    1653 |
-| Covid\_indirect\_interactions                | PROTEIN INTERACTIONS             |    6781 |
-| Implicated\_in\_viral\_infection             | PROTEIN INTERACTIONS             |    1904 |
-| max\_phase                                   | DRUGS FOR TARGET                 |    1191 |
-| drugs\_in\_clinic                            | DRUGS FOR TARGET                 |    1191 |
-| has\_invitro\_covid\_activity                | DRUGS FOR TARGET                 |     522 |
-| invitro\_covid\_activity                     | DRUGS FOR TARGET                 |     522 |
+|:---------------------------------------------|:---------------------------------|--------:|
+| scientificName                               | TARGET INFO                      |   27682 |
+| name                                         | TARGET INFO                      |   27650 |
+| biotype                                      | TARGET INFO                      |   27650 |
+| description                                  | TARGET INFO                      |   27628 |
+| uniprot\_ids                                 | TARGET INFO                      |   19882 |
+| COVID-19 UniprotKB                           | TARGET INFO                      |      92 |
+| FILTER\_network                              | FILTERS                          |    8573 |
+| FILTER\_network+drug                         | FILTERS                          |     439 |
+| FILTER\_network+covid\_tests                 | FILTERS                          |    8874 |
+| Covid\_direct\_interactions                  | PROTEIN INTERACTIONS             |    2009 |
+| Covid\_indirect\_interactions                | PROTEIN INTERACTIONS             |    7566 |
+| Implicated\_in\_viral\_infection             | PROTEIN INTERACTIONS             |    2387 |
+| max\_phase                                   | DRUGS FOR TARGET                 |    1202 |
+| drugs\_in\_clinic                            | DRUGS FOR TARGET                 |    1202 |
+| has\_invitro\_covid\_activity                | DRUGS FOR TARGET                 |     520 |
+| invitro\_covid\_activity                     | DRUGS FOR TARGET                 |     520 |
 | has\_drug\_in\_covid\_trials                 | DRUGS FOR TARGET                 |      99 |
-| hpa\_subcellular\_location                   | BASELINE GENE EXPRESSION         |   12297 |
-| hpa\_rna\_tissue\_distribution               | BASELINE GENE EXPRESSION         |   19347 |
-| hpa\_rna\_tissue\_specificity                | BASELINE GENE EXPRESSION         |   19347 |
-| hpa\_rna\_specific\_tissues                  | BASELINE GENE EXPRESSION         |   10838 |
-| respiratory\_system\_is\_expressed           | BASELINE GENE EXPRESSION         |   20124 |
-| respiratory\_system\_expressed\_tissue\_list | BASELINE GENE EXPRESSION         |   26021 |
-| immune\_system\_is\_expressed                | BASELINE GENE EXPRESSION         |   22765 |
-| immune\_system\_expressed\_tissue\_list      | BASELINE GENE EXPRESSION         |   26021 |
-| is\_abundance\_reg\_on\_covid                | COVID-19 HOST PROTEIN REGULATION |    1147 |
-| abundance\_reg\_on\_covid                    | COVID-19 HOST PROTEIN REGULATION |    1147 |
-| Tractability\_Top\_bucket\_(sm)              | TARGET TRACTABILITY              |    5035 |
-| Tractability\_Top\_bucket\_(ab)              | TARGET TRACTABILITY              |    9882 |
-| Tractability\_Top\_bucket\_(other)           | TARGET TRACTABILITY              |     215 |
+| hpa\_subcellular\_location                   | BASELINE GENE EXPRESSION         |   12709 |
+| hpa\_rna\_tissue\_distribution               | BASELINE GENE EXPRESSION         |   19364 |
+| hpa\_rna\_tissue\_specificity                | BASELINE GENE EXPRESSION         |   19364 |
+| hpa\_rna\_specific\_tissues                  | BASELINE GENE EXPRESSION         |   10848 |
+| respiratory\_system\_is\_expressed           | BASELINE GENE EXPRESSION         |   20132 |
+| respiratory\_system\_expressed\_tissue\_list | BASELINE GENE EXPRESSION         |   26039 |
+| immune\_system\_is\_expressed                | BASELINE GENE EXPRESSION         |   22778 |
+| immune\_system\_expressed\_tissue\_list      | BASELINE GENE EXPRESSION         |   26039 |
+| is\_abundance\_reg\_on\_covid                | COVID-19 HOST PROTEIN REGULATION |    1145 |
+| abundance\_reg\_on\_covid                    | COVID-19 HOST PROTEIN REGULATION |    1145 |
+| Tractability\_Top\_bucket\_(sm)              | TARGET TRACTABILITY              |    5030 |
+| Tractability\_Top\_bucket\_(ab)              | TARGET TRACTABILITY              |    9890 |
+| Tractability\_Top\_bucket\_(other)           | TARGET TRACTABILITY              |     222 |
 | has\_safety\_risk                            | TARGET SAFETY                    |     439 |
 | safety\_info\_source                         | TARGET SAFETY                    |     439 |
 | safety\_organs\_systems\_affected            | TARGET SAFETY                    |     193 |
-| covid\_literature                            | LITERATURE                       |     264 |
+| covid\_literature                            | LITERATURE                       |    1096 |


### PR DESCRIPTION
Data updates:
- OpenTargets data update to 21.02
- IntAct data update: human interactions and covid complex.
- Ensembl data update: human genome json file

Changes in the result summary:
- Slightly higher number of targets
- General increase for COVID related fields, specially the `literature` one.