### PR TITLE
Check whether required binaries exist before proceeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,33 @@ WIKIDATASERVER=https://query.wikidata.org/bigdata/namespace/wdq/sparql
 
 # bins
 CURL ?= $(shell which curl)
+ifeq ($(CURL),)
+$(error command "curl" not found)
+endif
 GUNZIP ?= $(shell which gunzip)
+ifeq ($(GUNZIP),)
+$(error command "gunzip" not found)
+endif
 JQ ?= $(shell which jq)
+ifeq ($(JQ),)
+$(error command "jq" not found)
+endif
 SED ?= $(shell which sed)
+ifeq ($(SED),)
+$(error command "sed" not found)
+endif
 PIPENV ?= $(shell which pipenv)
+ifeq ($(PIPENV),)
+$(error command "pipenv" not found)
+endif
 R ?= $(shell which R)
+ifeq ($(R),)
+$(error command "R" not found)
+endif
 RSCRIPT ?= $(shell which Rscript)
+ifeq ($(RSCRIPT),)
+$(error command "Rscript" not found)
+endif
 
 #################################
 # Paths (DIRECTORIES)


### PR DESCRIPTION
Hi there!

I added some checks to the `Makefile` that I found useful when running the pipeline on my machine. If one of the required tools is missing, e.g. `pipenv`, it will return an error and stop execution. Without these checks, the respective variable (`PIPENV`) might be empty and lead to the following (non-obvious) error

```sh
make setup-environment
install
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
make: *** [setup-environment] Error 64
```

as a result of this line in the `Makefile`

```make
setup-environment:
	$(PIPENV) install
```

It's clear from the docs that `pipenv` is a requirement, so this is just to avoid preventable errors.

The downside is that you must have all tools installed/available even if you just want to run of the steps that may not require one of the tools.

Please let me know what you think.